### PR TITLE
DL-1133 raised coverage by ignoring untestable files

### DIFF
--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -1,6 +1,7 @@
 import play.routes.compiler.StaticRoutesGenerator
 import sbt.Keys._
 import sbt._
+import scoverage.ScoverageKeys
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
@@ -23,10 +24,22 @@ trait MicroService {
   lazy val playSettings : Seq[Setting[_]] = Seq.empty
 
 
+  lazy val scoverageSettings = {
+    import scoverage._
+    Seq(
+      // Semicolon-separated list of regexs matching classes to exclude
+      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;config.*;.*(AuthService|BuildInfo|Routes).*",
+      ScoverageKeys.coverageMinimum := 80,
+      ScoverageKeys.coverageFailOnMinimum := false,
+      ScoverageKeys.coverageHighlighting := true
+    )
+  }
+
   lazy val microservice = Project(appName, file("."))
     .enablePlugins(Seq(play.sbt.PlayScala,SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins : _*)
     .settings(playSettings : _*)
     .settings(scalaSettings: _*)
+    .settings(playSettings ++ scoverageSettings : _*)
     .settings(publishingSettings: _*)
     .settings(defaultSettings(): _*)
     .settings(


### PR DESCRIPTION
# DL-1133 raised coverage by ignoring untestable files

**Maintenance**

Due to no coverage settings being used, files that should have been excluded from the report were bringing down the coverage percentage. It has now got appropriate coverage settings, raising the coverage level to 88.16% from the previous 69.14%

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
