### PR TITLE
play25Json adding missing config as part of upgrade

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,6 +35,9 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.MicroserviceModule"
 play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.MicroserviceFilters"
 
+# Json error handler
+play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
+
 # Secret key
 # ~~~~~
 # The secret key is used to secure cryptographics functions.


### PR DESCRIPTION
play25Json - adding missing config

**Fix**

Observed that some Json error handling config had been missed when upgrading to bootstrap play 25

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
